### PR TITLE
Reverse order of previous signatory batch

### DIFF
--- a/pages/letter/index.html
+++ b/pages/letter/index.html
@@ -214,89 +214,89 @@
             <li><cite>David Morar</cite>, Open Technology Institute</li>
             <li><cite>Frédérick Douzet</cite>, IFG - GEODE, Université Paris 8</li>
             <li><cite>Yacine Jernite</cite>, Hugging Face</li>
-            <li><cite>Benedito Alberto Macedo</cite>, CESAR - Centro de Estudos e Sistemas Avançados do Recife</li>
-            <li><cite>Jean-Yves Lemoine</cite>, KIDOMA</li>
-            <li><cite>Linda Griffin</cite>, Mozilla</li>
-            <li><cite>Cristina Giannone</cite>, Almawave spa</li>
-            <li><cite>Hugh Molotsi</cite>, Mozilla</li>
-            <li><cite>Nirmal Patel</cite> Playpower Labs</li>
-            <li><cite>Aleks Jakulin</cite>, Katalys</li>
-            <li><cite>Matthew Douglas</cite>, PERQ</li>
-            <li><cite>Radouane Oudrhiri</cite>, Systonomy</li>
-            <li><cite>Ida Momennejad</cite>, Microsoft research</li>
-            <li><cite>John Cook</cite>, Alignment Lab AI</li>
-            <li><cite>Jan Lukavský</cite>, Freelance</li>
-            <li><cite>Martin Andrews</cite>, Red Dragon AI</li>
-            <li><cite>Javier de la Rosa</cite>, National Library of Norway</li>
-            <li><cite>Vikash Sehwag</cite>, Sony AI</li>
-            <li><cite>Aaron Gokaslan</cite>, Cornell University</li>
-            <li><cite>Adam Clark</cite>, Anu</li>
-            <li><cite>Masayo Nobe</cite>, Mozilla</li>
-            <li><cite>Nikolaj Groeneweg</cite>, La French Tech</li>
-            <li><cite>Peter Prescott</cite>, 90 Percent of Everything</li>
-            <li><cite>Shaji Sebastian</cite>, Independent</li>
-            <li><cite>Adnan Durresi</cite>, Indiana University Indianapolis</li>
-            <li><cite>Yadava Aryal</cite>, Consultant</li>
-            <li><cite>Christian Szegedy</cite>, xAI</li>
-            <li><cite>Matthew Guzdial</cite>, University of Alberta</li>
-            <li><cite>Richard Dartois</cite>, Mars Incorporated</li>
-            <li><cite>Bastian Greshake Tzovaras</cite>,	Open Humans Foundation</li>
-            <li><cite>David Cabo</cite>, Fundación Civio</li>
-            <li><cite>Nicholas von Beroldingen</cite>, ENPLAN</li>
-            <li><cite>Elvis Saravia</cite>, DAIR.AI</li>
-            <li><cite>Mike Conley</cite>, Mozilla</li>
-            <li><cite>Martin Laprise</cite>, Hectiq AI</li>
-            <li><cite>Ife Adebara</cite>, University of British Columbia</li>
-            <li><cite>Christina Lang</cite>, Mozilla</li>
-            <li><cite>Chetanya Rastogi</cite>, Stanford</li>
-            <li><cite>Macduff Hughes</cite>, Google</li>
-            <li><cite>Furkan Uzumcu</cite>, Autodesk</li>
-            <li><cite>Jeffrey Silverman</cite>, Mozilla</li>
-            <li><cite>Andy Walters</cite>, Lexii.ai</li>
-            <li><cite>Ruthvik Reddy</cite>, SL Employee</li>
-            <li><cite>Alan Mackworth</cite>, Computer Science, UBC</li>
-            <li><cite>Eugen Hotaj</cite>, Meta</li>
-            <li><cite>Richard Kelley</cite>, Nevada Autonomous</li>
-            <li><cite>Tim van Erven</cite>, University of Amsterdam</li>
-            <li><cite>Jade Abbott</cite>, Lelapa AI</li>
-            <li><cite>Adeel Zaman</cite>, Aquila</li>
-            <li><cite>Tim Scarfe</cite>, Machine Learning Street Talk</li>
-            <li><cite>Kartik Ayyar</cite>, Roblox</li>
-            <li><cite>yves jacquier</cite>, Ubisoft</li>
-            <li><cite>Karen Ullrich</cite>, Meta AI</li>
-            <li><cite>Kabir Mohammed</cite>, CPrompt AI</li>
-            <li><cite>Xiaolin Ge</cite>, Hybrid Algorithms LLC</li>
-            <li><cite>Jonathan Larkin</cite>, Columbia University</li>
-            <li><cite>Derek Slater</cite>, Proteus Strategies</li>
-            <li><cite>Nuno Gonçalves</cite>, IST</li>
-            <li><cite>Lily Clifford</cite>,	Rime Labs</li>
-            <li><cite>Phil Lopes</cite>, Lusófona University</li>
-            <li><cite>Haiping Lu</cite>, University of Sheffield</li>
-            <li><cite>Lea Gimpel</cite>, Digital Public Goods Alliance</li>
-            <li><cite>Yasin Schroeder</cite>, Bildbrauerei GmbH</li>
-            <li><cite>Edouard Reinach</cite>, Trampoline AI</li>
-            <li><cite>Rinat Shaykhutdinov</cite>, Exabyte</li>
-            <li><cite>Ehud Lamm</cite>, Tel Aviv University</li>
-            <li><cite>Yury Leonychev</cite>, Intellics K.K.</li>
-            <li><cite>Siddharth Agrawal</cite>, Motorola Solutions</li>
-            <li><cite>Robert Toth</cite>, ThetaTech.ai</li>
-            <li><cite>Ludovic Huraux</cite>, Wingmate</li>
-            <li><cite>Vishal Burman</cite>, InSyncAI</li>
-            <li><cite>Luis Capelo</cite>, Modal Labs</li>
-            <li><cite>Diamond Bishop</cite>, Augmend AI</li>
-            <li><cite>Ganesh Kumar</cite>, Ex-Meta</li>
-            <li><cite>Johannes Burr</cite>, Deutsche Bahn</li>
-            <li><cite>Adnan Masood, PhD.</cite>, UST, Stanford Visiting Scholar, Microsoft Regional Director</li>
-            <li><cite>Brian Mills Jr</cite>, OpenSourceSoftware.eth</li>
-            <li><cite>Artur Garcez</cite>, City, University of London</li>
-            <li><cite>Sarah Kiden</cite>, Northumbria University</li>
-            <li><cite>Nantas Nardelli</cite>, Carbon Re</li>
-            <li><cite>Chris Lengerich</cite>, Context Fund</li>
-            <li><cite>Abhiram Kandiyana</cite>, University of South Florida</li>
-            <li><cite>Manlio De Domenico</cite>, University of Padua</li>
-            <li><cite>Anshul Kundaje</cite>, Stanford University</li>
-            <li><cite>Bharath Ramsundar</cite>, Industry</li>
             <li><cite>Arnav Arora</cite>, University of Copenhagen</li>
+            <li><cite>Bharath Ramsundar</cite>, Industry</li>
+            <li><cite>Anshul Kundaje</cite>, Stanford University</li>
+            <li><cite>Manlio De Domenico</cite>, University of Padua</li>
+            <li><cite>Abhiram Kandiyana</cite>, University of South Florida</li>
+            <li><cite>Chris Lengerich</cite>, Context Fund</li>
+            <li><cite>Nantas Nardelli</cite>, Carbon Re</li>
+            <li><cite>Sarah Kiden</cite>, Northumbria University</li>
+            <li><cite>Artur Garcez</cite>, City, University of London</li>
+            <li><cite>Brian Mills Jr</cite>, OpenSourceSoftware.eth</li>
+            <li><cite>Adnan Masood, PhD.</cite>, UST, Stanford Visiting Scholar, Microsoft Regional Director</li>
+            <li><cite>Johannes Burr</cite>, Deutsche Bahn</li>
+            <li><cite>Ganesh Kumar</cite>, Ex-Meta</li>
+            <li><cite>Diamond Bishop</cite>, Augmend AI</li>
+            <li><cite>Luis Capelo</cite>, Modal Labs</li>
+            <li><cite>Vishal Burman</cite>, InSyncAI</li>
+            <li><cite>Ludovic Huraux</cite>, Wingmate</li>
+            <li><cite>Robert Toth</cite>, ThetaTech.ai</li>
+            <li><cite>Siddharth Agrawal</cite>, Motorola Solutions</li>
+            <li><cite>Yury Leonychev</cite>, Intellics K.K.</li>
+            <li><cite>Ehud Lamm</cite>, Tel Aviv University</li>
+            <li><cite>Rinat Shaykhutdinov</cite>, Exabyte</li>
+            <li><cite>Edouard Reinach</cite>, Trampoline AI</li>
+            <li><cite>Yasin Schroeder</cite>, Bildbrauerei GmbH</li>
+            <li><cite>Lea Gimpel</cite>, Digital Public Goods Alliance</li>
+            <li><cite>Haiping Lu</cite>, University of Sheffield</li>
+            <li><cite>Phil Lopes</cite>, Lusófona University</li>
+            <li><cite>Lily Clifford</cite>,	Rime Labs</li>
+            <li><cite>Nuno Gonçalves</cite>, IST</li>
+            <li><cite>Derek Slater</cite>, Proteus Strategies</li>
+            <li><cite>Jonathan Larkin</cite>, Columbia University</li>
+            <li><cite>Xiaolin Ge</cite>, Hybrid Algorithms LLC</li>
+            <li><cite>Kabir Mohammed</cite>, CPrompt AI</li>
+            <li><cite>Karen Ullrich</cite>, Meta AI</li>
+            <li><cite>yves jacquier</cite>, Ubisoft</li>
+            <li><cite>Kartik Ayyar</cite>, Roblox</li>
+            <li><cite>Tim Scarfe</cite>, Machine Learning Street Talk</li>
+            <li><cite>Adeel Zaman</cite>, Aquila</li>
+            <li><cite>Jade Abbott</cite>, Lelapa AI</li>
+            <li><cite>Tim van Erven</cite>, University of Amsterdam</li>
+            <li><cite>Richard Kelley</cite>, Nevada Autonomous</li>
+            <li><cite>Eugen Hotaj</cite>, Meta</li>
+            <li><cite>Alan Mackworth</cite>, Computer Science, UBC</li>
+            <li><cite>Ruthvik Reddy</cite>, SL Employee</li>
+            <li><cite>Andy Walters</cite>, Lexii.ai</li>
+            <li><cite>Jeffrey Silverman</cite>, Mozilla</li>
+            <li><cite>Furkan Uzumcu</cite>, Autodesk</li>
+            <li><cite>Macduff Hughes</cite>, Google</li>
+            <li><cite>Chetanya Rastogi</cite>, Stanford</li>
+            <li><cite>Christina Lang</cite>, Mozilla</li>
+            <li><cite>Ife Adebara</cite>, University of British Columbia</li>
+            <li><cite>Martin Laprise</cite>, Hectiq AI</li>
+            <li><cite>Mike Conley</cite>, Mozilla</li>
+            <li><cite>Elvis Saravia</cite>, DAIR.AI</li>
+            <li><cite>Nicholas von Beroldingen</cite>, ENPLAN</li>
+            <li><cite>David Cabo</cite>, Fundación Civio</li>
+            <li><cite>Bastian Greshake Tzovaras</cite>,	Open Humans Foundation</li>
+            <li><cite>Richard Dartois</cite>, Mars Incorporated</li>
+            <li><cite>Matthew Guzdial</cite>, University of Alberta</li>
+            <li><cite>Christian Szegedy</cite>, xAI</li>
+            <li><cite>Yadava Aryal</cite>, Consultant</li>
+            <li><cite>Adnan Durresi</cite>, Indiana University Indianapolis</li>
+            <li><cite>Shaji Sebastian</cite>, Independent</li>
+            <li><cite>Peter Prescott</cite>, 90 Percent of Everything</li>
+            <li><cite>Nikolaj Groeneweg</cite>, La French Tech</li>
+            <li><cite>Masayo Nobe</cite>, Mozilla</li>
+            <li><cite>Adam Clark</cite>, Anu</li>
+            <li><cite>Aaron Gokaslan</cite>, Cornell University</li>
+            <li><cite>Vikash Sehwag</cite>, Sony AI</li>
+            <li><cite>Javier de la Rosa</cite>, National Library of Norway</li>
+            <li><cite>Martin Andrews</cite>, Red Dragon AI</li>
+            <li><cite>Jan Lukavský</cite>, Freelance</li>
+            <li><cite>John Cook</cite>, Alignment Lab AI</li>
+            <li><cite>Ida Momennejad</cite>, Microsoft research</li>
+            <li><cite>Radouane Oudrhiri</cite>, Systonomy</li>
+            <li><cite>Matthew Douglas</cite>, PERQ</li>
+            <li><cite>Aleks Jakulin</cite>, Katalys</li>
+            <li><cite>Nirmal Patel</cite> Playpower Labs</li>
+            <li><cite>Hugh Molotsi</cite>, Mozilla</li>
+            <li><cite>Cristina Giannone</cite>, Almawave spa</li>
+            <li><cite>Linda Griffin</cite>, Mozilla</li>
+            <li><cite>Jean-Yves Lemoine</cite>, KIDOMA</li>
+            <li><cite>Benedito Alberto Macedo</cite>, CESAR - Centro de Estudos e Sistemas Avançados do Recife</li>
           </ol>
         </div>
       </div>


### PR DESCRIPTION
We're taking signatory names from a spreadsheet and I took them from the top down, but that spreadsheet actually lists names with the most recent at the top and oldest at the bottom... so this reverses the order of the previously added batch of names to reflect the correct signing order.