### PR TITLE
Add thanks page

### DIFF
--- a/pages/letter/thanks/index.html
+++ b/pages/letter/thanks/index.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block page_title %}Thank you!{% endblock %}
+{% block page_desc %}{% endblock %}
+
+{% block page_css %}<link rel="stylesheet" href="/css/style.scss">{% endblock %}
+
+{% block content %}
+<div class="mzp-l-content mzp-t-content-md">
+  <h1>Thanks!</h1>
+  <p>Thank you for lending your voice to this initiative. We’ll add your name to the list of signatories.</p>
+
+  <ul>
+    <li><a href="https://open.mozilla.org/letter/">Read the Joint Statement on AI Safety and Openness</a></li>
+    <li><a href="https://open.mozilla.org/letter/#signatures">See the full list of signatories</a></li>
+  </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
Adds a basic page at /letter/thanks/ that we can redirect to after someone confirms their email.