### PR TITLE
Prevent list items breaking across columns

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -114,6 +114,11 @@ $font-path: '../../fonts';
     .c-signatures-list {
         columns: 2;
         column-gap: $spacing-lg;
+
+        li {
+            display: inline-block;
+            min-width: 100%;
+        }
     }
 }
 


### PR DESCRIPTION
In the event a column ends unevenly its contents will continue in the next column. This can create situations where content breaks across columns:

![image](https://github.com/mozmeao/openletter/assets/205591/faf7f720-c37f-4f38-9740-5794964e2f93)

The "correct" solution to this is the CSS `widows` property, sadly not yet supported in Firefox. But setting the list-items to `inline-block` is an acceptable hack to prevent widows/orphans. Adding a `min-width` also prevents items from laying on one line if they're narrow.