### PR TITLE
Revert to grid layout for signatures

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -112,14 +112,15 @@ $font-path: '../../fonts';
     }
 
     .c-signatures-list {
-        columns: 2;
+        display: grid;
+        grid-template-columns: repeat(2, 50%);
         column-gap: $spacing-lg;
     }
 }
 
 @media #{$mq-lg} {
     .signatures .c-signatures-list {
-        columns: 4;
+        grid-template-columns: repeat(4, 25%);
     }
 }
 


### PR DESCRIPTION
Stakeholders want the earliest signatories at the top of the page, laid across rows. We had done this previously but there were complaints about the uneven spacing, which is unavoidable in a grid layout (the tallest item in a row sets the height for the entire row). We switched to a multi-column layout so the items would be more evenly spaced, but that affected the reading order. It was decided that elevating the earlier signatories to the top of the pager was more important than even spacing in each column, so now we're back to the grid.