### PR TITLE
Update GA ID

### DIFF
--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -11,7 +11,6 @@ window.dataLayer = window.dataLayer || [];
 
 
 if(!dntEnabled()) {
-    
     window.gtag = function () {
       window.dataLayer.push(arguments);
     };
@@ -19,10 +18,10 @@ if(!dntEnabled()) {
     const gaScript = document.createElement('script');
     gaScript.async = 'true';
     gaScript.type = 'text/javascript';
-    gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-74DYP283GP';
+    gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-GY6LYTE55B';
     const pageHead = document.getElementsByTagName('head')[0];
     pageHead.append(gaScript);
 
     window.gtag('js', new Date());
-    window.gtag('config', 'G-74DYP283GP');
+    window.gtag('config', 'G-GY6LYTE55B');
 }


### PR DESCRIPTION
This project started as a copy of the future.mozilla.org static site, and inadvertently copied the Google Analytics ID along with it and we never changed it. So traffic data from this site is being intermingled with the other site, making both sites harder to read. This updates open.mozilla.org with a new ID so data will be clean going forward, though it does also mean a fresh start for this site.