### PR TITLE
adding signatures & changing root redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -51,7 +51,7 @@
 
 [[redirects]]
   from = "/"
-  to = "/economists/"
+  to = "/ai-safety/"
   force = true
 
 [[redirects]]

--- a/pages/economists/index.html
+++ b/pages/economists/index.html
@@ -90,7 +90,7 @@
         companies to proactively promote, rather than restrict, developments that
         foster open source AI.</p>
 
-      <p><i>We thank the Mozilla Foundation and Keystone Strategy for their support
+      <p><i>We thank the Mozilla Foundation and associates for their support
         in convening the signatories of this letter.</i></p>
 
       <aside class="c-share">
@@ -131,12 +131,14 @@
         <li><cite>Claudia Goldin</cite>, Harvard University</li>
         <li><cite>Manuel Hoffmann</cite>, Harvard University</li>
         <li><cite>John Horton</cite>, Massachusetts Institute of Technology</li>
+        <li><cite>Scott Kominers</cite>, Harvard University</li>
         <li><cite>Karim Lakhani</cite>, Harvard University</li>
         <li><cite>Frank Levy</cite>, Massachusetts Institute of Technology</li>
         <li><cite>Zachary Lipton</cite>, Carnegie Mellon University</li>
         <li><cite>Sendhil Mullainathan</cite>, Massachusetts Institute of Technology</li>
         <li><cite>Frank Nagle</cite>, Harvard University</li>
         <li><cite>Abhishek Nagaraj</cite>, University of California, Berkeley</li>
+        <li><cite>Andrea Renda</cite>, European University Institute</li>
         <li><cite>Daniel Rock</cite>, University of Pennsylvania</li>
         <li><cite>Robert Seamans</cite>, New York University</li>
         <li><cite>Steve Tadelis</cite>, University of California, Berkeley</li>


### PR DESCRIPTION
Adding the following signatories:
- Scott Kominers, Harvard University
- Andrea Renda, European University Institute

root domain to redirect to
https://open.mozilla.org/ai-safety/